### PR TITLE
Replace gulp-minify-css with gulp-clean-css

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -7,7 +7,7 @@ var filter = require('gulp-filter');
 var inject = require('gulp-inject');
 var rename = require('gulp-rename');
 var flatten = require('gulp-flatten');
-var minifyCSS = require('gulp-minify-css');
+var cleanCSS = require('gulp-clean-css');
 var minifyHTML = require('gulp-minify-html');
 var plumber = require('gulp-plumber');
 var sourcemaps = require('gulp-sourcemaps');
@@ -307,7 +307,7 @@ gulp.task('build.assets.prod', [
         .pipe(minifyHTML(HTMLMinifierOpts))
         .pipe(filterHTML.restore())
         .pipe(filterCSS)
-        .pipe(minifyCSS())
+        .pipe(cleanCSS())
         .pipe(filterCSS.restore())
         .pipe(gulp.dest(PATH.dest.prod.all));
 });

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -30,7 +30,7 @@
 "gulp-concat": "^2.5.2",
 "gulp-filter": "^2.0.2",
 "gulp-inject": "^1.3.1",
-"gulp-minify-css": "^1.1.6",
+"gulp-clean-css": "^2.0.7",
 "gulp-minify-html": "^1.0.3",
 "gulp-plumber": "~1.0.1",
 "gulp-sourcemaps": "~1.5.2",


### PR DESCRIPTION
**"gulp-minify-css"** has been deprecated  there for need to be replaced with a new repository.
**"gulp-clean-css"** seems to be a great replacement for the job.

In case you need i8 compatibility add pass an object with compatibility: 'ie8' to the gulp file in the pipe like so: 
`
.pipe(cleanCSS({compatibility: 'ie8'}))
`
